### PR TITLE
Implement text marshalers for bytes types

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -137,6 +137,11 @@ func (x *Bytes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalText marshals the bytes to text.
+func (x Bytes) MarshalText() ([]byte, error) {
+	return []byte(x.String()), nil
+}
+
 // String returns a base64 raw URL encoding of the bytes.
 func (x Bytes) String() string {
 	return base64.RawURLEncoding.EncodeToString([]byte(x))
@@ -207,8 +212,8 @@ func (x Bytes32) MarshalJSON() ([]byte, error) {
 	return json.Marshal(base64.RawURLEncoding.EncodeToString(x[:]))
 }
 
-// UnmarshalJSON unmarshals the bytes from JSON. This is done by decoding the
-// bytes from a base64 raw URL encoded string.
+// UnmarshalJSON unmarshals the 32-byte array from JSON. This is done by
+// decoding the bytes from a base64 raw URL encoded string.
 func (x *Bytes32) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
@@ -223,6 +228,11 @@ func (x *Bytes32) UnmarshalJSON(data []byte) error {
 	}
 	copy(x[:], data)
 	return nil
+}
+
+// MarshalText marshals the 32-byte array to text.
+func (x Bytes32) MarshalText() ([]byte, error) {
+	return []byte(x.String()), nil
 }
 
 // String returns a base64 raw URL encoding of the bytes.
@@ -292,8 +302,8 @@ func (x Bytes65) MarshalJSON() ([]byte, error) {
 	return json.Marshal(base64.RawURLEncoding.EncodeToString(x[:]))
 }
 
-// UnmarshalJSON unmarshals the bytes from JSON. This is done by decoding the
-// bytes from a base64 raw URL encoded string.
+// UnmarshalJSON unmarshals the 65-byte array from JSON. This is done by
+// decoding the bytes from a base64 raw URL encoded string.
 func (x *Bytes65) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
@@ -308,6 +318,11 @@ func (x *Bytes65) UnmarshalJSON(data []byte) error {
 	}
 	copy(x[:], data)
 	return nil
+}
+
+// MarshalText marshals the 65-byte array to text.
+func (x Bytes65) MarshalText() ([]byte, error) {
+	return []byte(x.String()), nil
 }
 
 // String returns a base64 raw URL encoding of the bytes.

--- a/bytes.go
+++ b/bytes.go
@@ -137,9 +137,21 @@ func (x *Bytes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalText marshals the bytes to text.
+// MarshalText marshals the bytes to text. This is done by encoding the bytes
+// into a base64 raw URL encoded string.
 func (x Bytes) MarshalText() ([]byte, error) {
-	return []byte(x.String()), nil
+	return []byte(base64.RawURLEncoding.EncodeToString([]byte(x))), nil
+}
+
+// UnmarshalText unmarshals the bytes from text. This is done by decoding the
+// bytes from a base64 raw URL encoded string.
+func (x *Bytes) UnmarshalText(text []byte) error {
+	data, err := base64.RawURLEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	*x = data
+	return nil
 }
 
 // String returns a base64 raw URL encoding of the bytes.
@@ -230,9 +242,24 @@ func (x *Bytes32) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalText marshals the 32-byte array to text.
+// MarshalText marshals the 32-byte array to text. This is done by encoding the
+// bytes into a base64 raw URL encoded string.
 func (x Bytes32) MarshalText() ([]byte, error) {
-	return []byte(x.String()), nil
+	return []byte(base64.RawURLEncoding.EncodeToString(x[:])), nil
+}
+
+// UnmarshalText unmarshals the 32-byte array from text. This is done by decoding the
+// bytes from a base64 raw URL encoded string.
+func (x *Bytes32) UnmarshalText(text []byte) error {
+	data, err := base64.RawURLEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(data) != 32 {
+		return fmt.Errorf("expected len=32, got len=%v", len(data))
+	}
+	copy(x[:], data)
+	return nil
 }
 
 // String returns a base64 raw URL encoding of the bytes.
@@ -320,9 +347,24 @@ func (x *Bytes65) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalText marshals the 65-byte array to text.
+// MarshalText marshals the 65-byte array to text. This is done by encoding the
+// bytes into a base64 raw URL encoded string.
 func (x Bytes65) MarshalText() ([]byte, error) {
-	return []byte(x.String()), nil
+	return []byte(base64.RawURLEncoding.EncodeToString(x[:])), nil
+}
+
+// UnmarshalText unmarshals the 65-byte array from text. This is done by decoding the
+// bytes from a base64 raw URL encoded string.
+func (x *Bytes65) UnmarshalText(text []byte) error {
+	data, err := base64.RawURLEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(data) != 65 {
+		return fmt.Errorf("expected len=65, got len=%v", len(data))
+	}
+	copy(x[:], data)
+	return nil
 }
 
 // String returns a base64 raw URL encoding of the bytes.

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -228,6 +228,48 @@ var _ = Describe("Bytes", func() {
 		})
 	})
 
+	Context("when marshaling and unmarshaling byte slices to and from text", func() {
+		It("should return itself", func() {
+			f := func(x pack.Bytes) bool {
+				data, err := x.MarshalText()
+				Expect(err).ToNot(HaveOccurred())
+				y := pack.Bytes{}
+				err = y.UnmarshalText(data)
+				Expect(err).ToNot(HaveOccurred())
+				return x.Equal(y)
+			}
+			Expect(quick.Check(f, nil)).To(Succeed())
+		})
+	})
+
+	Context("when marshaling and unmarshaling byte32 arrays to and from text", func() {
+		It("should return itself", func() {
+			f := func(x pack.Bytes32) bool {
+				data, err := x.MarshalText()
+				Expect(err).ToNot(HaveOccurred())
+				y := pack.Bytes32{}
+				err = y.UnmarshalText(data)
+				Expect(err).ToNot(HaveOccurred())
+				return x.Equal(&y)
+			}
+			Expect(quick.Check(f, nil)).To(Succeed())
+		})
+	})
+
+	Context("when marshaling and unmarshaling byte65 arrays to and from text", func() {
+		It("should return itself", func() {
+			f := func(x pack.Bytes65) bool {
+				data, err := x.MarshalText()
+				Expect(err).ToNot(HaveOccurred())
+				y := pack.Bytes65{}
+				err = y.UnmarshalText(data)
+				Expect(err).ToNot(HaveOccurred())
+				return x.Equal(&y)
+			}
+			Expect(quick.Check(f, nil)).To(Succeed())
+		})
+	})
+
 	Context("when stringifying strings", func() {
 		It("should return itself", func() {
 			f := func(x string) bool {


### PR DESCRIPTION
This allows us to use the `Bytes`, `Bytes32`, and `Bytes65` types as map keys.