### PR TITLE
Fix type equality checks and improve unmarshaling

### DIFF
--- a/list.go
+++ b/list.go
@@ -21,12 +21,12 @@ func NewList(vs ...Value) (List, error) {
 
 	elems := make([]Value, len(vs))
 	var t Type
-	for i := range elems {
+	for i := range vs {
 		// Verify the list elements have a consistent type.
 		if t == nil {
 			t = vs[i].Type()
-		} else if vs[i].Type() != t {
-			return List{}, fmt.Errorf("inconsistent list type: expected %v, got %v", t, elems[i].Type())
+		} else if !vs[i].Type().Equals(t) {
+			return List{}, fmt.Errorf("inconsistent list type: expected %v, got %v", t, vs[i].Type())
 		}
 		elems[i] = vs[i]
 	}

--- a/type.go
+++ b/type.go
@@ -1,7 +1,6 @@
 package pack
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -37,15 +36,8 @@ func (typeBool) Kind() Kind {
 }
 
 func (t typeBool) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeBool)
+	return ok
 }
 
 func (typeBool) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -111,15 +103,8 @@ func (typeU8) Kind() Kind {
 }
 
 func (t typeU8) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU8)
+	return ok
 }
 
 func (typeU8) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -185,15 +170,8 @@ func (typeU16) Kind() Kind {
 }
 
 func (t typeU16) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU16)
+	return ok
 }
 
 func (typeU16) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -259,15 +237,8 @@ func (typeU32) Kind() Kind {
 }
 
 func (t typeU32) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU32)
+	return ok
 }
 
 func (typeU32) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -333,15 +304,8 @@ func (typeU64) Kind() Kind {
 }
 
 func (t typeU64) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU64)
+	return ok
 }
 
 func (typeU64) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -407,15 +371,8 @@ func (typeU128) Kind() Kind {
 }
 
 func (t typeU128) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU128)
+	return ok
 }
 
 func (typeU128) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -481,15 +438,8 @@ func (typeU256) Kind() Kind {
 }
 
 func (t typeU256) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeU256)
+	return ok
 }
 
 func (typeU256) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -555,15 +505,8 @@ func (typeString) Kind() Kind {
 }
 
 func (t typeString) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeString)
+	return ok
 }
 
 func (typeString) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -629,15 +572,8 @@ func (typeBytes) Kind() Kind {
 }
 
 func (t typeBytes) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeBytes)
+	return ok
 }
 
 func (typeBytes) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -703,15 +639,8 @@ func (typeBytes32) Kind() Kind {
 }
 
 func (t typeBytes32) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeBytes32)
+	return ok
 }
 
 func (typeBytes32) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -777,15 +706,8 @@ func (typeBytes65) Kind() Kind {
 }
 
 func (t typeBytes65) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
-		return false
-	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	_, ok := other.(typeBytes65)
+	return ok
 }
 
 func (typeBytes65) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -920,15 +842,22 @@ func (typeStruct) Kind() Kind {
 }
 
 func (t typeStruct) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
+	otherStruct, ok := other.(typeStruct)
+	if !ok {
 		return false
 	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
+	if len(t) != len(otherStruct) {
 		return false
 	}
-	return bytes.Equal(a, b)
+	for i := range t {
+		if t[i].Name != otherStruct[i].Name {
+			return false
+		}
+		if !t[i].Type.Equals(otherStruct[i].Type) {
+			return false
+		}
+	}
+	return true
 }
 
 func (t typeStruct) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -1050,15 +979,11 @@ func (typeList) Kind() Kind {
 }
 
 func (t typeList) Equals(other Type) bool {
-	a, err := surge.ToBinary(t)
-	if err != nil {
+	otherList, ok := other.(typeList)
+	if !ok {
 		return false
 	}
-	b, err := surge.ToBinary(other)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(a, b)
+	return t.Type.Equals(otherList.Type)
 }
 
 func (t typeList) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {

--- a/type.go
+++ b/type.go
@@ -14,6 +14,7 @@ import (
 // A Type is a concrete type definition for a value.
 type Type interface {
 	surge.Marshaler
+	json.Marshaler
 
 	// Kind returns the abstract "type of the type" for this type.
 	Kind() Kind
@@ -67,8 +68,40 @@ func (t typeBool) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeBool) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeBool) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeBool) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeBool) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU8 struct{}
@@ -109,8 +142,40 @@ func (t typeU8) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU8) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU8) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU8) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU8) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU16 struct{}
@@ -151,8 +216,40 @@ func (t typeU16) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU16) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU16) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU16) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU16) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU32 struct{}
@@ -193,8 +290,40 @@ func (t typeU32) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU32) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU32) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU32) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU32) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU64 struct{}
@@ -235,8 +364,40 @@ func (t typeU64) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU64) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU64) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU64) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU64) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU128 struct{}
@@ -277,8 +438,40 @@ func (t typeU128) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU128) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU128) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU128) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU128) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeU256 struct{}
@@ -319,8 +512,40 @@ func (t typeU256) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeU256) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeU256) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeU256) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeU256) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeString struct{}
@@ -361,8 +586,40 @@ func (t typeString) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeString) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeString) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeString) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeString) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeBytes struct{}
@@ -403,8 +660,40 @@ func (t typeBytes) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeBytes) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeBytes) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeBytes) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeBytes) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeBytes32 struct{}
@@ -445,8 +734,40 @@ func (t typeBytes32) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeBytes32) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeBytes32) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeBytes32) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeBytes32) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeBytes65 struct{}
@@ -487,8 +808,40 @@ func (t typeBytes65) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	return t.Kind().Marshal(buf, rem)
 }
 
-func (t typeBytes65) MarshalText() ([]byte, error) {
-	return t.Kind().MarshalText()
+func (t *typeBytes65) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
+	var kind Kind
+	var err error
+	buf, rem, err = kind.Unmarshal(buf, rem)
+	if err != nil {
+		return buf, rem, err
+	}
+	if kind != t.Kind() {
+		return buf, rem, fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return buf, rem, nil
+}
+
+func (t typeBytes65) MarshalJSON() ([]byte, error) {
+	data, err := t.Kind().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(data))
+}
+
+func (t *typeBytes65) UnmarshalJSON(data []byte) error {
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	var kind Kind
+	if err := kind.UnmarshalText([]byte(text)); err != nil {
+		return err
+	}
+	if kind != t.Kind() {
+		return fmt.Errorf("unexpected kind: expected %v, got %v", t.Kind(), kind)
+	}
+	return nil
 }
 
 type typeStructField struct {
@@ -757,6 +1110,16 @@ func (t typeList) Marshal(buf []byte, rem int) ([]byte, int, error) {
 
 func (t *typeList) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
 	return UnmarshalType(&t.Type, buf, rem)
+}
+
+func (t typeList) MarshalJSON() ([]byte, error) {
+	return marshalTypeJSON(t.Type)
+}
+
+func (t *typeList) UnmarshalJSON(data []byte) error {
+	var err error
+	t.Type, err = unmarshalTypeJSON(data)
+	return err
 }
 
 // SizeHintType returns the number of bytes requires to represent this type in

--- a/type.go
+++ b/type.go
@@ -1,6 +1,7 @@
 package pack
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -17,6 +18,10 @@ type Type interface {
 	// Kind returns the abstract "type of the type" for this type.
 	Kind() Kind
 
+	// Equals returns a boolean indicating whether or not the given type is
+	// identical to the current one.
+	Equals(other Type) bool
+
 	// Unmarshal a value of this type from binary.
 	UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error)
 
@@ -28,6 +33,18 @@ type typeBool struct{}
 
 func (typeBool) Kind() Kind {
 	return KindBool
+}
+
+func (t typeBool) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeBool) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -60,6 +77,18 @@ func (typeU8) Kind() Kind {
 	return KindU8
 }
 
+func (t typeU8) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
 func (typeU8) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
 	value := U8(0)
 	buf, rem, err := value.Unmarshal(buf, rem)
@@ -88,6 +117,18 @@ type typeU16 struct{}
 
 func (typeU16) Kind() Kind {
 	return KindU16
+}
+
+func (t typeU16) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeU16) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -120,6 +161,18 @@ func (typeU32) Kind() Kind {
 	return KindU32
 }
 
+func (t typeU32) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
 func (typeU32) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
 	value := U32(0)
 	buf, rem, err := value.Unmarshal(buf, rem)
@@ -148,6 +201,18 @@ type typeU64 struct{}
 
 func (typeU64) Kind() Kind {
 	return KindU64
+}
+
+func (t typeU64) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeU64) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -180,6 +245,18 @@ func (typeU128) Kind() Kind {
 	return KindU128
 }
 
+func (t typeU128) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
 func (typeU128) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
 	value := U128{}
 	buf, rem, err := value.Unmarshal(buf, rem)
@@ -208,6 +285,18 @@ type typeU256 struct{}
 
 func (typeU256) Kind() Kind {
 	return KindU256
+}
+
+func (t typeU256) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeU256) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -240,6 +329,18 @@ func (typeString) Kind() Kind {
 	return KindString
 }
 
+func (t typeString) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
 func (typeString) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
 	value := String("")
 	buf, rem, err := value.Unmarshal(buf, rem)
@@ -268,6 +369,18 @@ type typeBytes struct{}
 
 func (typeBytes) Kind() Kind {
 	return KindBytes
+}
+
+func (t typeBytes) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeBytes) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -300,6 +413,18 @@ func (typeBytes32) Kind() Kind {
 	return KindBytes32
 }
 
+func (t typeBytes32) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
+}
+
 func (typeBytes32) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
 	value := Bytes32{}
 	buf, rem, err := value.Unmarshal(buf, rem)
@@ -328,6 +453,18 @@ type typeBytes65 struct{}
 
 func (typeBytes65) Kind() Kind {
 	return KindBytes65
+}
+
+func (t typeBytes65) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (typeBytes65) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -427,6 +564,18 @@ type typeStruct []typeStructField
 
 func (typeStruct) Kind() Kind {
 	return KindStruct
+}
+
+func (t typeStruct) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (t typeStruct) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {
@@ -545,6 +694,18 @@ type typeList struct {
 
 func (typeList) Kind() Kind {
 	return KindList
+}
+
+func (t typeList) Equals(other Type) bool {
+	a, err := surge.ToBinary(t)
+	if err != nil {
+		return false
+	}
+	b, err := surge.ToBinary(other)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(a, b)
 }
 
 func (t typeList) UnmarshalValue(buf []byte, rem int) (Value, []byte, int, error) {


### PR DESCRIPTION
Previously the type comparison inside the `List` constructor was just checking if the two `Type` interfaces were equal. This was unreliable (e.g. when comparing two `typeStruct` types), and as a result the `Type` interface has been updated to contain an `Equals` function. Additionally, concrete unmarshalers have been implemented for the types to ensure the data being unmarshaled is actually valid.