### PR TITLE
Support encoding/decoding values

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -40,6 +40,8 @@ func Encode(v interface{}) (Value, error) {
 		return v, nil
 	case Typed:
 		return v, nil
+	case Value:
+		return v, nil
 	}
 
 	// Otherwise, reflect on the kind/type of the interface, and convert it into
@@ -214,6 +216,12 @@ func Decode(interf interface{}, v Value) error {
 		}
 		if v, ok := v.(Struct); ok {
 			*interf = Typed(v)
+			return nil
+		}
+		return fmt.Errorf("unexpected value of type %T", v)
+	case *Value:
+		if v, ok := v.(Value); ok {
+			*interf = v
 			return nil
 		}
 		return fmt.Errorf("unexpected value of type %T", v)

--- a/encode_test.go
+++ b/encode_test.go
@@ -147,7 +147,8 @@ var _ = Describe("Encoding", func() {
 		It("should equal itself", func() {
 			var x pack.Value
 
-			x = pack.NewBool(false)
+			r := rand.New(rand.NewSource(GinkgoRandomSeed()))
+			x = pack.Generate(r, 1, true, true).Interface().(pack.Value)
 			encoded, err := pack.Encode(x)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -145,9 +145,9 @@ var _ = Describe("Encoding", func() {
 
 	Context("when encoding and then decoding a value", func() {
 		It("should equal itself", func() {
-			var x pack.Value
-
 			r := rand.New(rand.NewSource(GinkgoRandomSeed()))
+
+			var x pack.Value
 			x = pack.Generate(r, 1, true, true).Interface().(pack.Value)
 			encoded, err := pack.Encode(x)
 			Expect(err).ToNot(HaveOccurred())
@@ -155,6 +155,8 @@ var _ = Describe("Encoding", func() {
 			var y pack.Value
 			err = pack.Decode(&y, encoded)
 			Expect(err).ToNot(HaveOccurred())
+
+			Expect(reflect.DeepEqual(x, y)).To(BeTrue())
 		})
 	})
 })

--- a/encode_test.go
+++ b/encode_test.go
@@ -7,9 +7,10 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/renproject/pack"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/renproject/pack"
 )
 
 var _ = Describe("Encoding", func() {
@@ -141,4 +142,18 @@ var _ = Describe("Encoding", func() {
 			})
 		})
 	}
+
+	Context("when encoding and then decoding a value", func() {
+		It("should equal itself", func() {
+			var x pack.Value
+
+			x = pack.NewBool(false)
+			encoded, err := pack.Encode(x)
+			Expect(err).ToNot(HaveOccurred())
+
+			var y pack.Value
+			err = pack.Decode(&y, encoded)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
This PR updates the `Encode` and `Decode` functions to support the `pack.Value` type.