### PR TITLE
Fix decoding into struct with new fields

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -280,11 +280,15 @@ func Decode(interf interface{}, v Value) error {
 			}
 			return fmt.Errorf("unexpected value of type %T", v)
 		}
-		elem.Set(reflect.MakeSlice(typeOf, len(v.(List).Elems), len(v.(List).Elems)))
-		for i := 0; i < len(v.(List).Elems); i++ {
-			if err := Decode(elem.Index(i).Addr().Interface(), v.(List).Elems[i]); err != nil {
-				return fmt.Errorf("decoding list item: %v", err)
+		if v, ok := v.(List); ok {
+			elem.Set(reflect.MakeSlice(typeOf, len(v.Elems), len(v.Elems)))
+			for i := 0; i < len(v.Elems); i++ {
+				if err := Decode(elem.Index(i).Addr().Interface(), v.Elems[i]); err != nil {
+					return fmt.Errorf("decoding list item: %v", err)
+				}
 			}
+		} else {
+			elem.Set(reflect.MakeSlice(typeOf, 0, 0))
 		}
 		return nil
 	case reflect.Array:

--- a/encode.go
+++ b/encode.go
@@ -7,7 +7,13 @@ import (
 )
 
 // Encode a Go interface into a Value interface.
-func Encode(v interface{}) (Value, error) {
+func Encode(v interface{}) (val Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered: %v", err)
+			return
+		}
+	}()
 
 	// If the interface is already a value, then immediately return the
 	// interface without modification.
@@ -126,7 +132,13 @@ func Encode(v interface{}) (Value, error) {
 
 // Decode a Value interface into a Go interface. The Go interface must be a
 // pointer.
-func Decode(interf interface{}, v Value) error {
+func Decode(interf interface{}, v Value) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered: %v", err)
+			return
+		}
+	}()
 
 	// If the interface-to-be-decoded-into is a value, then check the type of
 	// the value-to-be-decoded, and assign.

--- a/encode.go
+++ b/encode.go
@@ -333,9 +333,8 @@ func Decode(interf interface{}, v Value) error {
 				}
 			}
 			if name != "" {
-				// If the field is equivalent to the zero element, do not decode
-				// it.
-				if reflect.DeepEqual(elem.Field(i).Interface(), reflect.Zero(elem.Field(i).Type()).Interface()) {
+				// If the struct value is nil, do not decode it.
+				if structOrTyped.Get(name) == nil {
 					continue
 				}
 				if err := Decode(elem.Field(i).Addr().Interface(), structOrTyped.Get(name)); err != nil {

--- a/encode.go
+++ b/encode.go
@@ -280,15 +280,11 @@ func Decode(interf interface{}, v Value) error {
 			}
 			return fmt.Errorf("unexpected value of type %T", v)
 		}
-		if v, ok := v.(List); ok {
-			elem.Set(reflect.MakeSlice(typeOf, len(v.Elems), len(v.Elems)))
-			for i := 0; i < len(v.Elems); i++ {
-				if err := Decode(elem.Index(i).Addr().Interface(), v.Elems[i]); err != nil {
-					return fmt.Errorf("decoding list item: %v", err)
-				}
+		elem.Set(reflect.MakeSlice(typeOf, len(v.(List).Elems), len(v.(List).Elems)))
+		for i := 0; i < len(v.(List).Elems); i++ {
+			if err := Decode(elem.Index(i).Addr().Interface(), v.(List).Elems[i]); err != nil {
+				return fmt.Errorf("decoding list item: %v", err)
 			}
-		} else {
-			elem.Set(reflect.MakeSlice(typeOf, 0, 0))
 		}
 		return nil
 	case reflect.Array:
@@ -337,6 +333,11 @@ func Decode(interf interface{}, v Value) error {
 				}
 			}
 			if name != "" {
+				// If the field is equivalent to the zero element, do not decode
+				// it.
+				if reflect.DeepEqual(elem.Field(i).Interface(), reflect.Zero(elem.Field(i).Type()).Interface()) {
+					continue
+				}
 				if err := Decode(elem.Field(i).Addr().Interface(), structOrTyped.Get(name)); err != nil {
 					return fmt.Errorf("decoding \"%v\": %v", f.Name, err)
 				}

--- a/encode_test.go
+++ b/encode_test.go
@@ -163,10 +163,10 @@ var _ = Describe("Encoding", func() {
 			var x A
 			err = pack.Decode(&x, v)
 			Expect(err).ToNot(HaveOccurred())
-			var y A
+			var y B
 			err = pack.Decode(&y, v)
 			Expect(err).ToNot(HaveOccurred())
-			var z A
+			var z C
 			err = pack.Decode(&z, v)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/encode_test.go
+++ b/encode_test.go
@@ -138,42 +138,14 @@ var _ = Describe("Encoding", func() {
 	})
 
 	type PartialStruct struct {
-		Y    pack.U64 `json:"y"`
-		Omit pack.U64 `json:"z,omitempty"`
-		Dash pack.U64 `json:"-"`
-
-		Foo pack.String  `json:"foo"`
-		Boo pack.Bytes65 `json:"boo"`
-
-		Inner struct {
-			InnerX       pack.U64 `json:"x"`
-			InnerUnnamed pack.U64
-		} `json:"inner"`
-
-		List pack.List `json:"list"`
+		Foo pack.String `json:"foo"`
 	}
 
 	type Struct struct {
-		X       pack.U64 `json:"x"`
-		Y       pack.U64 `json:"y"`
-		Omit    pack.U64 `json:"z,omitempty"`
-		Dash    pack.U64 `json:"-"`
-		Unnamed pack.U64
-
-		Foo pack.String  `json:"foo"`
-		Bar pack.Bytes   `json:"bar"`
-		Baz pack.Bytes32 `json:"baz"`
-		Boo pack.Bytes65 `json:"boo"`
-
-		Inner struct {
-			InnerX       pack.U64 `json:"x"`
-			InnerY       pack.U64 `json:"y"`
-			InnerOmit    pack.U64 `json:"z,omitempty"`
-			InnerDash    pack.U64 `json:"-"`
-			InnerUnnamed pack.U64
-		} `json:"inner"`
-
-		List pack.List `json:"list"`
+		Foo pack.U64    `json:"foo"`
+		Bar pack.String `json:"bar"`
+		Baz pack.Bytes  `json:"baz"`
+		Boo pack.List   `json:"boo"`
 	}
 
 	Context("when decoding into a struct with new fields", func() {

--- a/encode_test.go
+++ b/encode_test.go
@@ -138,22 +138,36 @@ var _ = Describe("Encoding", func() {
 	})
 
 	type PartialStruct struct {
-		Foo pack.String `json:"foo"`
+		Foo pack.U64 `json:"foo"`
 	}
 
-	type Struct struct {
+	type A struct {
 		Foo pack.U64    `json:"foo"`
 		Bar pack.String `json:"bar"`
-		Baz pack.Bytes  `json:"baz"`
-		Boo pack.List   `json:"boo"`
+	}
+
+	type B struct {
+		Foo pack.U64   `json:"foo"`
+		Baz pack.Bytes `json:"baz"`
+	}
+
+	type C struct {
+		Foo pack.U64  `json:"foo"`
+		Boo pack.List `json:"boo"`
 	}
 
 	Context("when decoding into a struct with new fields", func() {
 		It("should not error", func() {
 			v, err := pack.Encode(PartialStruct{})
 			Expect(err).ToNot(HaveOccurred())
-			var x Struct
+			var x A
 			err = pack.Decode(&x, v)
+			Expect(err).ToNot(HaveOccurred())
+			var y A
+			err = pack.Decode(&y, v)
+			Expect(err).ToNot(HaveOccurred())
+			var z A
+			err = pack.Decode(&z, v)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/int.go
+++ b/int.go
@@ -515,6 +515,9 @@ func (u128 U128) Bytes() []byte {
 }
 
 func (u128 U128) Add(other U128) U128 {
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	ret := U128{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u128.inner)
@@ -528,6 +531,9 @@ func (u128 U128) Add(other U128) U128 {
 }
 
 func (u128 U128) Sub(other U128) U128 {
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	ret := U128{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u128.inner)
@@ -541,6 +547,9 @@ func (u128 U128) Sub(other U128) U128 {
 }
 
 func (u128 U128) Mul(other U128) U128 {
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	ret := U128{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u128.inner)
@@ -554,6 +563,9 @@ func (u128 U128) Mul(other U128) U128 {
 }
 
 func (u128 U128) Div(other U128) U128 {
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	ret := U128{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u128.inner)
@@ -767,6 +779,9 @@ func (u256 U256) Bytes() []byte {
 }
 
 func (u256 U256) Add(other U256) U256 {
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	ret := U256{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u256.inner)
@@ -780,6 +795,9 @@ func (u256 U256) Add(other U256) U256 {
 }
 
 func (u256 U256) Sub(other U256) U256 {
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	ret := U256{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u256.inner)
@@ -793,6 +811,9 @@ func (u256 U256) Sub(other U256) U256 {
 }
 
 func (u256 U256) Mul(other U256) U256 {
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	ret := U256{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u256.inner)
@@ -806,6 +827,9 @@ func (u256 U256) Mul(other U256) U256 {
 }
 
 func (u256 U256) Div(other U256) U256 {
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	ret := U256{inner: new(big.Int)}
 	if other.inner == nil {
 		ret.inner.Set(u256.inner)

--- a/int.go
+++ b/int.go
@@ -659,6 +659,9 @@ func (u128 U128) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	if len(buf) < 16 || rem < 16 {
 		return buf, rem, surge.ErrUnexpectedEndOfBuffer
 	}
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	b16 := paddedTo16(u128.inner)
 	copy(buf, b16[:])
 	return buf[16:], rem - 16, nil
@@ -678,6 +681,9 @@ func (u128 *U128) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
 }
 
 func (u128 U128) MarshalJSON() ([]byte, error) {
+	if u128.inner == nil {
+		u128.inner = new(big.Int)
+	}
 	return json.Marshal(u128.String())
 }
 
@@ -923,6 +929,9 @@ func (u256 U256) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	if len(buf) < 32 || rem < 32 {
 		return buf, rem, surge.ErrUnexpectedEndOfBuffer
 	}
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	b32 := paddedTo32(u256.inner)
 	copy(buf, b32[:])
 	return buf[32:], rem - 32, nil
@@ -942,6 +951,9 @@ func (u256 *U256) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
 }
 
 func (u256 U256) MarshalJSON() ([]byte, error) {
+	if u256.inner == nil {
+		u256.inner = new(big.Int)
+	}
 	return json.Marshal(u256.String())
 }
 

--- a/packutil/packutil.go
+++ b/packutil/packutil.go
@@ -68,6 +68,11 @@ func AddZeroCheck(t reflect.Type) error {
 	if !result[0].Bool() {
 		return fmt.Errorf("unequal after adding zero")
 	}
+	result = y.MethodByName("Add").Call([]reflect.Value{x})
+	result = result[0].MethodByName("Equal").Call([]reflect.Value{x})
+	if !result[0].Bool() {
+		return fmt.Errorf("unequal after adding zero")
+	}
 	// AddAssign zero
 	before := x.Interface().(fmt.Stringer).String()
 	xPtr := reflect.New(t)


### PR DESCRIPTION
This fixes an issue where an encoded struct cannot be decoded into a struct containing new fields. For example, if we encode the following object:

```
type A struct {
    Foo pack.String `json:"foo"`
}
```

And later introduce a new field to the struct `A`:

```
type A struct {
    Foo pack.String `json:"foo"`
    Bar pack.Bytes `json:"bar"`
}
```

We will be met with the following error when decoding the original encoded value into the new object: `decoding \"Bar\": unexpected value of type <nil>`. To resolve this, we simply skip the decoding process if the struct field is nil.